### PR TITLE
Fix: Change return of the api to type data dinamic

### DIFF
--- a/src/main/java/br/com/bank/movements/application/MovementApi.java
+++ b/src/main/java/br/com/bank/movements/application/MovementApi.java
@@ -18,10 +18,12 @@ import java.util.Optional;
 @AllArgsConstructor
 @RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE)
 public class MovementApi {
+    public static final String NOT_FOUND_RETURN = "0";
+
     private final RegistrationEvent registrationEvent;
 
     @PostMapping(value = "/event")
-    public ResponseEntity<EventResult> registerEvent(@RequestBody Event newEvent) {
+    public ResponseEntity<?> registerEvent(@RequestBody Event newEvent) {
         Optional<EventResult> eventResult = registrationEvent.add(newEvent);
 
         if (eventResult.isPresent()) {
@@ -29,7 +31,7 @@ public class MovementApi {
 
             return ResponseEntity.status(HttpStatus.CREATED).body(valueEventsResult);
         } else {
-            return ResponseEntity.notFound().build();
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(NOT_FOUND_RETURN);
         }
     }
 }


### PR DESCRIPTION
# Description

To adapt the application of the IPkiss tests it was necessary to change the data type int to string in the account id field.

## Fixes 

### Fail return of api


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

 N/A

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules